### PR TITLE
Don't treat return code 3010 as a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Installs Microsoft Visual C++ runtime version 6 (2005), 9 (2008), 10 (2010), 11 
 - Microsoft Windows 2008 R2
 - Microsoft Windows 2012
 - Microsoft Windows 2012 R2
+- Microsoft Windows 2016
+- Microsoft Windows 2019
 
 ### Chef
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,10 +12,16 @@ provisioner:
 platforms:
   - name: windows-2008r2
     driver_config:
-      box: chef/windows-server-2008r2-standard
+      box: tas50/windows_2008r2
   - name: windows-2012r2
     driver_config:
-      box: chef/windows-server-2012r2-standard
+      box: tas50/windows_2012r2
+  - name: windows-2016
+    driver_config:
+      box: tas50/windows_2016
+  - name: windows-2019
+    driver_config:
+      box: tas50/windows_2019
 
 suites:
   - name: all

--- a/recipes/vc10.rb
+++ b/recipes/vc10.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['name'] do
+    windows_package node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['name'] do
       checksum node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['sha256sum']
       source node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x64'][node['vcruntime']['vc10']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
+    windows_package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
       checksum node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum']
       source node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
+    windows_package node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name'] do
       checksum node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum']
       source node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc10']['x86'][node['vcruntime']['vc10']['version']]['sha256sum'],

--- a/recipes/vc11.rb
+++ b/recipes/vc11.rb
@@ -3,7 +3,7 @@
 # Cookbook:: vcruntime
 # Recipe:: vc11
 #
-# Copyright:: 2013-2017, Chef Software, Inc.
+# Copyright:: 2013-2019, Chef Software, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['name'] do
+    windows_package node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['name'] do
       checksum node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['sha256sum']
       source node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x64'][node['vcruntime']['vc11']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
+    windows_package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
       checksum node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum']
       source node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
+    windows_package node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name'] do
       checksum node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum']
       source node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc11']['x86'][node['vcruntime']['vc11']['version']]['sha256sum'],

--- a/recipes/vc12.rb
+++ b/recipes/vc12.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['name'] do
+    windows_package node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['name'] do
       checksum node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['sha256sum']
       source node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x64'][node['vcruntime']['vc12']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
+    windows_package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
       checksum node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum']
       source node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
+    windows_package node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name'] do
       checksum node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum']
       source node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc12']['x86'][node['vcruntime']['vc12']['version']]['sha256sum'],

--- a/recipes/vc14.rb
+++ b/recipes/vc14.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['name'] do
+    windows_package node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['name'] do
       checksum node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x64'][node['vcruntime']['vc14']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
+    windows_package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
       checksum node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
+    windows_package node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name'] do
       checksum node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum']
       source node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc14']['x86'][node['vcruntime']['vc14']['version']]['sha256sum'],

--- a/recipes/vc15.rb
+++ b/recipes/vc15.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['name'] do
+    windows_package node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['name'] do
       checksum node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['sha256sum']
       source node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc15']['x64'][node['vcruntime']['vc15']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name'] do
+    windows_package node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name'] do
       checksum node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['sha256sum']
       source node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name'] do
+    windows_package node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name'] do
       checksum node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['sha256sum']
       source node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc15']['x86'][node['vcruntime']['vc15']['version']]['sha256sum'],

--- a/recipes/vc6.rb
+++ b/recipes/vc6.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['name'] do
+    windows_package node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['name'] do
       checksum node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['sha256sum']
       source node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['name']} - #{node['vcruntime']['vc6']['version']}.exe",
         checksum: node['vcruntime']['vc6']['x64'][node['vcruntime']['vc6']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name'] do
+    windows_package node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name'] do
       checksum node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['sha256sum']
       source node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name']} - #{node['vcruntime']['vc6']['version']}.exe",
         checksum: node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name'] do
+    windows_package node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name'] do
       checksum node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['sha256sum']
       source node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['name']} - #{node['vcruntime']['vc6']['version']}.exe",
         checksum: node['vcruntime']['vc6']['x86'][node['vcruntime']['vc6']['version']]['sha256sum'],

--- a/recipes/vc9.rb
+++ b/recipes/vc9.rb
@@ -21,20 +21,22 @@
 if platform?('windows')
   case node['kernel']['machine']
   when 'x86_64'
-    package node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['name'] do
+    windows_package node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['name'] do
       checksum node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['sha256sum']
       source node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc9']['x64'][node['vcruntime']['vc9']['version']]['sha256sum'],
       })
       options '/q'
     end
-    package node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name'] do
+    windows_package node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name'] do
       checksum node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['sha256sum']
       source node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['sha256sum'],
@@ -42,10 +44,11 @@ if platform?('windows')
       options '/q'
     end
   when /i[3-6]86/
-    package node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name'] do
+    windows_package node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name'] do
       checksum node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['sha256sum']
       source node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['url']
       installer_type :custom
+      returns [0, 3010]
       remote_file_attributes ({
         path: "#{Chef::Config[:file_cache_path]}\\package\\#{node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['name']}.exe",
         checksum: node['vcruntime']['vc9']['x86'][node['vcruntime']['vc9']['version']]['sha256sum'],


### PR DESCRIPTION
@akdor1154 pointed out that 3010 is success with a restart required. We shouldn't fail the Chef run for that.

I also switched to windows_package directly to avoid a tiny bit of work routing the client too that. I've added additional Windows 2016/2019 testing using my public vagrant boxes.

Fixes #18

Signed-off-by: Tim Smith <tsmith@chef.io>